### PR TITLE
use S3 localtion for warehouse

### DIFF
--- a/config/hive-site-template.xml
+++ b/config/hive-site-template.xml
@@ -36,7 +36,7 @@
   <!-- Directory location for the Hive warehouse where table data is stored -->
   <property>
     <name>hive.metastore.warehouse.dir</name>
-    <value>/cdm_shared_workspace/hive_metastore</value>
+    <value>{{DELTALAKE_WAREHOUSE_DIR}}</value>
   </property>
 
   <!-- Enable support for concurrency in Hive, allowing multiple users to access and modify the data simultaneously -->

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -24,7 +24,8 @@ services:
       - DATANUCLEUS_AUTO_CREATE_TABLES=true
       - REDIS_HOST=redis
       - REDIS_PORT=6379
-
+      - DELTALAKE_WAREHOUSE_DIR=s3a://cdm-lake/warehouse
+      
   spark-worker-1:
     build:
       context: .
@@ -47,6 +48,7 @@ services:
       - DATANUCLEUS_AUTO_CREATE_TABLES=true
       - REDIS_HOST=redis
       - REDIS_PORT=6379
+      - DELTALAKE_WAREHOUSE_DIR=s3a://cdm-lake/warehouse
 
   spark-worker-2:
     build:
@@ -70,6 +72,7 @@ services:
       - DATANUCLEUS_AUTO_CREATE_TABLES=true
       - REDIS_HOST=redis
       - REDIS_PORT=6379
+      - DELTALAKE_WAREHOUSE_DIR=s3a://cdm-lake/warehouse
 
   spark-user:
     build:
@@ -81,6 +84,8 @@ services:
       - REDIS_HOST=redis
       - REDIS_PORT=6379
     command: /bin/bash -c "tail -f /dev/null"
+    volumes:
+      - ./scripts/redis_container_script.py:/app/redis_container_script.py
     depends_on:
       - spark-master
 

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -26,6 +26,7 @@ fi
 : "${EXECUTOR_CORES:=2}"             # Default executor cores to 2 if not set
 : "${MAX_CORES_PER_APPLICATION:=10}" # Default maximum cores per application to 10 if not set
 : "${DATANUCLEUS_AUTO_CREATE_TABLES:=true}" # Default DataNucleus auto create tables to true if not set
+: "${DELTALAKE_WAREHOUSE_DIR:=s3a://cdm-lake/warehouse}" # Default DeltaLake warehouse directory
 
 {
     # For detailed explanations and definitions of configuration options,
@@ -76,4 +77,5 @@ sed -e "s|{{POSTGRES_URL}}|${POSTGRES_URL}|g" \
     -e "s|{{POSTGRES_USER}}|${POSTGRES_USER}|g" \
     -e "s|{{POSTGRES_PASSWORD}}|${POSTGRES_PASSWORD}|g" \
     -e "s|{{DATANUCLEUS_AUTO_CREATE_TABLES}}|${DATANUCLEUS_AUTO_CREATE_TABLES}|g" \
+    -e "s|{{DELTALAKE_WAREHOUSE_DIR}}|${DELTALAKE_WAREHOUSE_DIR}|g" \
     /opt/config/hive-site-template.xml > "$SPARK_HOME"/conf/hive-site.xml


### PR DESCRIPTION
The `hive.metastore.warehouse.dir` setting takes precedence over `spark.sql.warehouse.dir`. I think we could configure the Hive warehouse location to point to S3, and set `spark.sql.warehouse.dir` in the driver when Hive is not being used there. When hive is enabled, I think we should always use S3. 