### PR TITLE
Adding spark-xml package to the cdm-spark-standalone

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -35,6 +35,7 @@ ENV DELTA_SPARK_VER=3.2.0
 ENV SCALA_VER=2.12
 ENV POSTGRES_JDBC_VER=42.2.23
 ENV SPARK_REDIS_VER=3.1.0
+ENV SPARK_XML_VER=0.18.0
 
 # Run Gradle task to download JARs to /gradle/gradle_jars location
 COPY build.gradle settings.gradle gradlew /gradle/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM bitnami/spark:3.5.1
+FROM bitnami/spark:3.5.6
 
 # Switch to root to install packages
 # https://github.com/bitnami/containers/tree/main/bitnami/spark#installing-additional-jars

--- a/build.gradle
+++ b/build.gradle
@@ -18,12 +18,14 @@ def deltaSparkVersion = System.getenv('DELTA_SPARK_VER')
 def scalaVersion = System.getenv('SCALA_VER')
 def postgresVersion = System.getenv('POSTGRES_JDBC_VER')
 def sparkRedisVersion = System.getenv('SPARK_REDIS_VER')
+def sparkXmlVersion = System.getenv('SPARK_XML_VER')
 
 dependencies {
     implementation "org.apache.hadoop:hadoop-aws:$hadoopAwsVersion"
     implementation "io.delta:delta-spark_${scalaVersion}:$deltaSparkVersion"
     implementation "org.postgresql:postgresql:$postgresVersion"
     implementation "com.redislabs:spark-redis_${scalaVersion}:$sparkRedisVersion"
+    implementation "com.databricks:spark-xml_${scalaVersion}:$sparkXmlVersion"
 }
 
 task downloadDependencies(type: Copy) {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ description = "CDM Spark Standalone"
 readme = "README.md"
 requires-python = "==3.11.9"
 dependencies = [
-    "pyspark==3.5.5",
+    "pyspark==3.5.6",
 ]
 
 [dependency-groups]

--- a/uv.lock
+++ b/uv.lock
@@ -27,7 +27,7 @@ dev = [
 ]
 
 [package.metadata]
-requires-dist = [{ name = "pyspark", specifier = "==3.5.5" }]
+requires-dist = [{ name = "pyspark", specifier = "==3.5.6" }]
 
 [package.metadata.requires-dev]
 dev = [
@@ -239,12 +239,12 @@ wheels = [
 
 [[package]]
 name = "pyspark"
-version = "3.5.5"
+version = "3.5.6"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "py4j" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/5f/8f/b616ef710932ccdbabd8511e08890a677482ab2967b7cf276c09a02bc64c/pyspark-3.5.5.tar.gz", hash = "sha256:6effc9ce98edf231f4d683fd14f7270629bf8458c628d6a2620ded4bb34f3cb9", size = 317214975, upload-time = "2025-02-27T09:16:31.75Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/2e/62/36e50d38e5fe158e97cddec983b44f9417b1e205b02320e3c463b5f802fa/pyspark-3.5.6.tar.gz", hash = "sha256:f8b1c4360e41ab398c64904fae08740503bcb6bd389457d659fa6d9f2952cc48", size = 317359167, upload-time = "2025-05-27T08:24:20.82Z" }
 
 [[package]]
 name = "pytest"


### PR DESCRIPTION
Add the spark-xml package to the CDM spark setup.

Tested locally with a simple script that reads XML and writes a subset of it to a new file -- basically the contents of the two samples here:

https://github.com/databricks/spark-xml?tab=readme-ov-file#python-api